### PR TITLE
Fix environment variable name

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,9 +93,9 @@ The passed volume is used to access the machine configuration from the container
     Default value is 5556.
     - YAML_FILE_PATH: The path where the parameters.yml file is located inside the container.
     Default path is /app/parameters.yml.
-    - SHUTDOWN_HOST: The host where the reboot command will be sent.
+    - SHUTDOWN_SERVICE_HOST: The host where the reboot command will be sent.
     Default value is "127.0.0.1"
-    - SHUTDOWN_PORT: The port where the reboot command will be sent.
+    - SHUTDOWN_SERVICE_PORT: The port where the reboot command will be sent.
     Default value is 5558
 
 ## Author

--- a/src/main.py
+++ b/src/main.py
@@ -15,8 +15,8 @@ LOG_LEVEL = os.environ.get("LOG_LEVEL", logging.INFO)
 BUTTON_EVENTS_HOST = os.environ.get("BUTTON_EVENTS_HOST", "127.0.0.1")
 BUTTON_EVENTS_PORT = int(os.environ.get("BUTTON_EVENTS_PORT" , 5556))
 YAML_FILE_PATH = os.environ.get("YAML_FILE_PATH", "/app/parameters.yml")
-SHUTDOWN_SERVICE_HOST = os.environ.get("SHUTDOWN_HOST", "127.0.0.1")
-SHUTDOWN_SERVICE_PORT = int(os.environ.get("SHUTDOWN_PORT", 5558))
+SHUTDOWN_SERVICE_HOST = os.environ.get("SHUTDOWN_SERVICE_HOST", "127.0.0.1")
+SHUTDOWN_SERVICE_PORT = int(os.environ.get("SHUTDOWN_SERVICE_PORT", 5558))
 
 CONFIG_HOST = "0.0.0.0"
 RESET_COMMAND = "reboot"


### PR DESCRIPTION
The name of the variable was the new one, but the name in `os.environ.get()` was the old name.

When merging this pull request a new tag will need to be created.